### PR TITLE
[add] buy_nice_timing 기능 추가

### DIFF
--- a/auto_trading_system.py
+++ b/auto_trading_system.py
@@ -27,3 +27,7 @@ class AutoTradingSystem:
 
     def get_price(self, code) -> int:
         return self.brocker.get_price(code)
+
+    def buy_nice_timing(self, code, money):
+        current_price = self.get_price(code)
+        self.buy(code, 100, 10)

--- a/auto_trading_system.py
+++ b/auto_trading_system.py
@@ -1,8 +1,10 @@
 from kiwer_driver import KiwerDriver
 from nemo_driver import NemoDriver
 
+
 class AutoTradingSystem:
     def __init__(self):
+        self.prev_price = {}
         self.NemoDriver = None
         self.KiwerDriver = None
         self.brocker = None
@@ -29,5 +31,7 @@ class AutoTradingSystem:
         return self.brocker.get_price(code)
 
     def buy_nice_timing(self, code, money):
+        self.prev_price[code] = self.get_price(code)
         current_price = self.get_price(code)
-        self.buy(code, 100, 10)
+        if self.prev_price[code] < current_price:
+            self.buy(code, current_price, money // current_price)

--- a/test_auto_trading_system.py
+++ b/test_auto_trading_system.py
@@ -44,7 +44,7 @@ class TestAutoTradingSystem(unittest.TestCase):
         self.system.buy = Mock()
 
         self.system.buy_nice_timing('0001', 1000)
-        self.system.get_price.assert_called_once_with('0001')
+        self.system.get_price.assert_called_with('0001')
         self.system.buy.assert_called_once_with('0001', 100, 10)
 
     def test_sell_nice_timing(self):


### PR DESCRIPTION
### 추세를 판단하기 위해 테스트 코드 일부 변경했습니다.
---
## biz logic
* buy_nice_timing 호출 시, 총 2번의 get_price 호출
* 첫 번째 get_price를 prev_price에 저장
* 두 번째 get_price와 prev_price를 비교해서 현재 가격이 이전 가격보다 높을 경우 매수
* 매수량은 <인자로 전달 받은 금액> // <해당 종목 현재 가격> 으로 결정